### PR TITLE
chore: add Counter component with off-by-one bug for routine demo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { Counter } from './Counter'
 import { FixMeButton } from './FixMeButton'
 
 export function App() {
@@ -5,11 +6,11 @@ export function App() {
     <main style={{ fontFamily: 'system-ui, sans-serif', padding: '2rem' }}>
       <h1>Automation Routine Demo</h1>
       <p>
-        Click the button below. Right now it is broken — it throws an error.
-        A Claude routine should be able to pick up the corresponding bug
-        ticket and fix it.
+        Components on this page are targeted by a nightly Claude routine
+        that watches the GitHub Project board for P1 bugs.
       </p>
       <FixMeButton />
+      <Counter />
     </main>
   )
 }

--- a/src/Counter.test.tsx
+++ b/src/Counter.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Counter } from './Counter'
+
+describe('Counter', () => {
+  it('starts at 0', () => {
+    render(<Counter />)
+    expect(screen.getByTestId('count')).toHaveTextContent('Count: 0')
+  })
+
+  it('increments by exactly 1 on a single click', () => {
+    render(<Counter />)
+    fireEvent.click(screen.getByRole('button', { name: /increment/i }))
+    expect(screen.getByTestId('count')).toHaveTextContent('Count: 1')
+  })
+
+  it('increments sequentially on multiple clicks (+1 each)', () => {
+    render(<Counter />)
+    const button = screen.getByRole('button', { name: /increment/i })
+    fireEvent.click(button)
+    fireEvent.click(button)
+    fireEvent.click(button)
+    expect(screen.getByTestId('count')).toHaveTextContent('Count: 3')
+  })
+})

--- a/src/Counter.tsx
+++ b/src/Counter.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+
+/**
+ * A simple counter with an "Increment" button.
+ *
+ * QA reported that clicking Increment bumps the count by the wrong amount.
+ * See Counter.test.tsx for the behavioural contract the fix must satisfy.
+ */
+export function Counter() {
+  const [count, setCount] = useState(0)
+
+  const increment = () => {
+    // BUG: should increment by 1, but increments by 2.
+    setCount((c) => c + 2)
+  }
+
+  return (
+    <div style={{ marginTop: '1.5rem' }}>
+      <span data-testid="count">Count: {count}</span>{' '}
+      <button type="button" onClick={increment}>
+        Increment
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
Sets up a second bug scenario for a live demo of the P1 bug auto-fix routine.

## What's added

- `src/Counter.tsx` — a counter with an Increment button whose handler bumps by **2 instead of 1** (the deliberate bug).
- `src/Counter.test.tsx` — three tests asserting +1 semantics. Two of them fail on the current buggy code.
- `src/App.tsx` — wires the Counter into the page so it renders in `npm run dev` for live-demo purposes.

## Local verification

- `npm run test` exits 1 — two of the three Counter tests fail (expected).
- `npm run build` exits 0 — TypeScript is happy; the failure is purely behavioural.

## How the demo works after merge

1. Merge this PR → broken code lands on `main`.
2. Create a new issue on the Project board (title e.g. `Counter increments by 2`), label `bug`, `Priority = P1`.
3. Paste the QA ticket body (see `.claude/TEST_TICKET.md` pattern).
4. Hit **Run now** on the `p1-bug-autofix` routine → routine discovers the ticket, branches, fixes the off-by-one, verifies with `npm run test && npm run build`, opens a draft PR.