### PR TITLE
chore: add ColoredButton with wrong colour + UI-mode docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,11 @@ dist-ssr
 # Coverage
 coverage
 
+# Routine screenshot artifacts. The UI-bug routine writes before/after
+# screenshots into __screenshots__/issue-<N>/ and force-adds them to the
+# fix branch (so they're embeddable from raw.githubusercontent.com on the
+# branch but never accidentally committed during interactive work).
+__screenshots__
+
 # TypeScript build info
 *.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,9 @@ and accurate.
 
 A throwaway Vite + React + TypeScript app used to validate the nightly
 **P1 bug auto-fix routine** described in
-`F:\Job\automation\claude-routines-integration.md`. The only "feature" is
-a `<FixMeButton>` component that is deliberately broken.
+`F:\Job\automation\claude-routines-integration.md`. The page renders a few
+deliberately broken components (or recently-fixed ones) for routine
+shakedowns — `<FixMeButton>`, `<Counter>`, `<ColoredButton>`.
 
 ## Commands
 
@@ -19,11 +20,10 @@ a `<FixMeButton>` component that is deliberately broken.
 | Type-check + build | `npm run build` |
 | Run tests (non-watch) | `npm run test` |
 | Lint | `npm run lint` (present but not wired into CI) |
-| Dev server | `npm run dev` |
+| Dev / preview server | `npm run dev` (port 5173) / `npm run preview` (port 4173 — for routine screenshots) |
 
-**Verification command for routines: `npm run test`.** This must pass
-before opening a PR. `npm run build` must also succeed (it catches TS
-errors the test suite won't).
+**Verification command for routines: `npm run test && npm run build`.**
+Both must exit 0 before pushing.
 
 ## Conventions
 
@@ -32,6 +32,80 @@ errors the test suite won't).
 - Keep changes surgical. Scope a fix to the ticket; do not refactor
   opportunistically.
 - Do not introduce new dependencies without a justification in the PR body.
+
+## Bug categories the routine handles
+
+The same routine handles two flavours of bug. Detection is based on the
+ticket body:
+
+### Code / logic bugs (default mode)
+
+- No Figma URL in the ticket body.
+- Fix the code, run `npm run test && npm run build`, push, draft PR.
+- Existing examples: FixMeButton (throw-on-click), Counter (off-by-one).
+
+### UI / visual bugs (Figma mode)
+
+Triggered when the ticket body contains a `https://www.figma.com/design/...`
+URL. The fix workflow has extra steps:
+
+1. **Read the Figma node** via `mcp__figma__get_design_context` (the Figma
+   connector is enabled on this routine). Extract the colour values,
+   spacing, typography from the design context — these are source of
+   truth, not the existing code.
+2. **Capture a "before" screenshot.** Start the preview server on the
+   pre-fix code:
+   ```bash
+   npm ci
+   npm run build
+   npm run preview &
+   PID=$!
+   sleep 3
+   npx playwright screenshot --full-page http://localhost:4173 \
+     /tmp/before.png
+   kill $PID
+   ```
+3. **Apply the fix** based on the Figma values.
+4. **Verify with tests:** `npm run test && npm run build`.
+5. **Capture an "after" screenshot** the same way against the patched
+   code:
+   ```bash
+   npm run build
+   npm run preview &
+   PID=$!
+   sleep 3
+   npx playwright screenshot --full-page http://localhost:4173 \
+     /tmp/after.png
+   kill $PID
+   ```
+6. **Commit screenshots into the branch** under
+   `__screenshots__/issue-<N>/`:
+   ```bash
+   mkdir -p __screenshots__/issue-$N
+   cp /tmp/before.png /tmp/after.png __screenshots__/issue-$N/
+   git add -f __screenshots__/issue-$N/
+   git commit -m "screenshots: before/after for #$N"
+   ```
+   Force-add (`-f`) is needed because `__screenshots__/` is in
+   `.gitignore` to prevent accidental commits during interactive work.
+7. **Embed both images in the PR body** using `raw.githubusercontent.com`
+   URLs. Template:
+   ```markdown
+   Fixes #<N>
+
+   <2-4 sentence summary of the visual change.>
+
+   ## Before / After
+
+   | Before | After |
+   |--------|-------|
+   | ![before](https://github.com/Metakirin/Automation/raw/<branch>/__screenshots__/issue-<N>/before.png) | ![after](https://github.com/Metakirin/Automation/raw/<branch>/__screenshots__/issue-<N>/after.png) |
+   ```
+
+If Playwright is not installed (sandbox setup script issue), fall back
+to: skip the screenshots, open the PR with code-only diff, mention in
+the PR body that screenshots were skipped due to environment limitation.
+Do NOT block the fix on the screenshot step.
 
 ## Branch & PR policy
 
@@ -48,5 +122,7 @@ errors the test suite won't).
 - Never pass `--no-verify` to `git commit` or `git push`. If a hook fails,
   fix the underlying issue.
 - Never commit `.env` files or secrets.
+- Never commit `node_modules/` or build artifacts (the `dist/` and
+  `coverage/` directories are in `.gitignore` already).
 - If tests fail after an honest attempt to fix the fix, abandon the issue,
   do not push the branch, log the failure in the run summary.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { ColoredButton } from './ColoredButton'
 import { Counter } from './Counter'
 import { FixMeButton } from './FixMeButton'
 
@@ -11,6 +12,7 @@ export function App() {
       </p>
       <FixMeButton />
       <Counter />
+      <ColoredButton />
     </main>
   )
 }

--- a/src/ColoredButton.test.tsx
+++ b/src/ColoredButton.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ColoredButton } from './ColoredButton'
+
+describe('ColoredButton', () => {
+  it('renders the "Click Me" label', () => {
+    render(<ColoredButton />)
+    expect(
+      screen.getByRole('button', { name: /click me/i })
+    ).toBeInTheDocument()
+  })
+
+  it('uses the Figma background colour (#fef3c7)', () => {
+    render(<ColoredButton />)
+    const button = screen.getByRole('button', { name: /click me/i })
+    // jsdom canonicalises hex inline styles to rgb()
+    expect(button.style.backgroundColor).toBe('rgb(254, 243, 199)')
+  })
+
+  it('uses the Figma text colour (#92400e)', () => {
+    render(<ColoredButton />)
+    const button = screen.getByRole('button', { name: /click me/i })
+    expect(button.style.color).toBe('rgb(146, 64, 14)')
+  })
+})

--- a/src/ColoredButton.tsx
+++ b/src/ColoredButton.tsx
@@ -1,0 +1,31 @@
+/**
+ * A "Click Me" button styled per a Figma design.
+ *
+ * QA reported that the colour does not match the Figma source of truth.
+ * The fix should bring the inline `style` into agreement with the design
+ * — see the Figma URL on the issue ticket and ColoredButton.test.tsx for
+ * the expected colour values.
+ */
+export function ColoredButton() {
+  return (
+    <button
+      type="button"
+      style={{
+        // BUG: wrong colours. Per Figma the button should be a soft yellow
+        // background (#fef3c7) with dark amber text (#92400e).
+        backgroundColor: '#dc2626',
+        color: '#ffffff',
+        border: 'none',
+        borderRadius: '10px',
+        padding: '10px 20px',
+        fontFamily: '"Inter", sans-serif',
+        fontWeight: 500,
+        fontSize: '16px',
+        lineHeight: '24px',
+        cursor: 'pointer',
+      }}
+    >
+      Click Me
+    </button>
+  )
+}


### PR DESCRIPTION
Stacked on top of #4 — merge that first, then this. After both land, `main` will have the broken Counter and the broken ColoredButton ready for two independent demos of the routine.

## What's added

- `src/ColoredButton.tsx` — a Click Me button styled red (`#dc2626` bg, white text) instead of the Figma-specified yellow (`#fef3c7` bg, `#92400e` text). Inline-style approach matches the existing pattern in `App.tsx`.
- `src/ColoredButton.test.tsx` — three tests; two fail asserting the Figma colour values.
- `src/App.tsx` — wires the new button into the page alongside FixMeButton and Counter.
- `CLAUDE.md` — adds a **Bug categories** section. New "UI / Figma mode" workflow:
  - Detect a `figma.com/design/...` URL in the ticket body → UI mode.
  - Pull authoritative colour/spacing/typography via `mcp__figma__get_design_context` (Figma connector enabled on the routine).
  - Capture before/after screenshots via `npx playwright screenshot http://localhost:4173` against `npm run preview`.
  - Commit screenshots under `__screenshots__/issue-<N>/`, embed in PR body via `raw.githubusercontent.com` URLs.
  - Falls back gracefully (skip screenshots, mention in PR) if Playwright is unavailable.
- `.gitignore` — excludes `__screenshots__/` from interactive-work commits; routine force-adds.

## Local verification

- `npm run test` exits 1 — the two ColoredButton colour tests fail (expected). Counter tests still fail too because this branch is stacked on PR #4.
- `npm run build` exits 0.

## Required env / routine changes (separate from this PR)

The routine prompt and the cloud environment's setup script also need updates to enable Playwright and switch on the Figma connector. Those will be applied via `RemoteTrigger.update` and the env-edit UI respectively, not in this PR.