### PR TITLE
fix: update ColoredButton colours to match Figma design (#7)

### DIFF
--- a/src/ColoredButton.tsx
+++ b/src/ColoredButton.tsx
@@ -11,10 +11,8 @@ export function ColoredButton() {
     <button
       type="button"
       style={{
-        // BUG: wrong colours. Per Figma the button should be a soft yellow
-        // background (#fef3c7) with dark amber text (#92400e).
-        backgroundColor: '#dc2626',
-        color: '#ffffff',
+        backgroundColor: '#fef3c7',
+        color: '#92400e',
         border: 'none',
         borderRadius: '10px',
         padding: '10px 20px',


### PR DESCRIPTION


Updated `ColoredButton` inline styles to match the Figma design node (K0yFH0Yr5qMy9TyC6ynxj0, node 1-3): background changed from `#dc2626` to `#fef3c7` (soft yellow) and text colour changed from `#ffffff` to `#92400e` (dark amber). All other style properties (border-radius 10px, Inter Medium 16px/24px, padding) were already correct and left untouched. All three `ColoredButton` tests now pass.

_Screenshots skipped: Playwright browsers unavailable in this run's sandbox._

---
Session: https://claude.ai/code/cse_01LisxrqvK7DhVh9WQx1e6bC

---
_Generated by [Claude Code](https://claude.ai/code/session_01LisxrqvK7DhVh9WQx1e6bC)_