### PR TITLE
fix: update ColoredButton colours to match Figma design (#7)

### DIFF
--- a/src/ColoredButton.tsx
+++ b/src/ColoredButton.tsx
@@ -11,10 +11,8 @@ export function ColoredButton() {
     <button
       type="button"
       style={{
-        // BUG: wrong colours. Per Figma the button should be a soft yellow
-        // background (#fef3c7) with dark amber text (#92400e).
-        backgroundColor: '#dc2626',
-        color: '#ffffff',
+        backgroundColor: '#fef3c7',
+        color: '#92400e',
         border: 'none',
         borderRadius: '10px',
         padding: '10px 20px',


### PR DESCRIPTION


Background colour changed from `#dc2626` (red) to `#fef3c7` (soft yellow) and text colour from `#ffffff` (white) to `#92400e` (dark amber), matching Figma node `K0yFH0Yr5qMy9TyC6ynxj0:1:3`. All three `ColoredButton` tests now pass and the build succeeds.

## Before / After

_Screenshots skipped: chromium binary unavailable in this run's sandbox (snap-based chromium cannot run headless without snap daemon)._

## Source of truth

Pulled spec from Figma node `K0yFH0Yr5qMy9TyC6ynxj0:1:3` via Figma MCP — `backgroundColor: #fef3c7`, `color: #92400e`, `borderRadius: 10px`, Inter Medium 16px / 24px line-height.

---
Session: https://claude.ai/code/cse_013mCnuCdKfdNPdgyQjehmrN

---
_Generated by [Claude Code](https://claude.ai/code/session_013mCnuCdKfdNPdgyQjehmrN)_