### PR TITLE
fix: update ColoredButton colours to match Figma design (#7)

### DIFF
--- a/src/ColoredButton.tsx
+++ b/src/ColoredButton.tsx
@@ -11,10 +11,8 @@ export function ColoredButton() {
     <button
       type="button"
       style={{
-        // BUG: wrong colours. Per Figma the button should be a soft yellow
-        // background (#fef3c7) with dark amber text (#92400e).
-        backgroundColor: '#dc2626',
-        color: '#ffffff',
+        backgroundColor: '#fef3c7',
+        color: '#92400e',
         border: 'none',
         borderRadius: '10px',
         padding: '10px 20px',


### PR DESCRIPTION
Fixes #7

The `<ColoredButton />` background was `#dc2626` (red) with `#ffffff` (white) text. Per Figma node `K0yFH0Yr5qMy9TyC6ynxj0:1:3`, the correct values are `#fef3c7` (soft yellow) background and `#92400e` (dark amber) text with 10px border-radius, Inter Medium 16px/24px. All three `ColoredButton` tests now pass and the build succeeds.

## Before / After

_Screenshots skipped: no working chromium-family binary in this run's sandbox._

## Source of truth

Pulled spec from Figma node `K0yFH0Yr5qMy9TyC6ynxj0:1:3` via `mcp__Figma__get_design_context` (Figma MCP available).

---
Session: https://claude.ai/code/cse_01UFx2QP6pVMT8JcaHxXpoE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFx2QP6pVMT8JcaHxXpoE4)_